### PR TITLE
Upgrade mysql-connector-java

### DIFF
--- a/keepchronos/database/pom.xml
+++ b/keepchronos/database/pom.xml
@@ -25,7 +25,7 @@
 		<dependency>
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>
-			<version>5.1.46</version>
+			<version>8.0.16</version>
 		</dependency>
 
 		<!-- JDBC (Java DataBase Connectivity) PostgreSQL -->


### PR DESCRIPTION
Upgrade mysql:mysql-connector-java to version 8.0.16 to fix CVE-2019-2692.